### PR TITLE
various ui tweaks

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -1,9 +1,31 @@
-button.osd.circular {
+button.custom-on-image {
   min-width: 42px;
   min-height: 42px;
+  margin: 12px;
 }
 
 .dragndrop_overlay {
   background-color: alpha(@accent_bg_color, 0.5);
   color: @accent_fg_color;
+}
+
+headerbar.desktop button.close image {
+    color: alpha(white, 0.9);
+    background: alpha(black, 0.6);
+}
+
+headerbar.desktop button.close:hover image {
+    background: alpha(mix(black, white, 0.1), 0.5);
+}
+
+headerbar.desktop button.close:active image {
+    background: alpha(mix(black, white, 0.2), 0.5);
+}
+
+.sheet-toolbar {
+    padding: 12px;
+}
+
+.red {
+    color: red;
 }

--- a/data/style.css
+++ b/data/style.css
@@ -9,16 +9,16 @@ button.custom-on-image {
   color: @accent_fg_color;
 }
 
-headerbar.desktop button.close image {
+headerbar.desktop windowcontrols button image {
     color: alpha(white, 0.9);
     background: alpha(black, 0.6);
 }
 
-headerbar.desktop button.close:hover image {
+headerbar.desktop windowcontrols button:hover image {
     background: alpha(mix(black, white, 0.1), 0.5);
 }
 
-headerbar.desktop button.close:active image {
+headerbar.desktop windowcontrols button:active image {
     background: alpha(mix(black, white, 0.2), 0.5);
 }
 

--- a/data/style.css
+++ b/data/style.css
@@ -25,7 +25,3 @@ headerbar.desktop button.close:active image {
 .sheet-toolbar {
     padding: 12px;
 }
-
-.red {
-    color: red;
-}

--- a/data/ui/dither_page.blp
+++ b/data/ui/dither_page.blp
@@ -341,10 +341,10 @@ Gtk.Popover options_information_popover {
 
 Gtk.Popover aspect_ratio_popover {
   Gtk.Label {
-    margin-top: 3;
-    margin-bottom: 3;
-    margin-start: 3;
-    margin-end: 3;
+    margin-top: 6;
+    margin-bottom: 6;
+    margin-start: 6;
+    margin-end: 6;
     wrap: true;
     justify: center;
     max-width-chars: 30;

--- a/data/ui/dither_page.blp
+++ b/data/ui/dither_page.blp
@@ -31,7 +31,7 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
           tooltip-text: _("Main Menu");
           icon-name: "open-menu-symbolic";
           menu-model: main_menu;
-          primary: true;
+          primary: bind split_view.show-sidebar;
         }
       }
     };

--- a/data/ui/dither_page.blp
+++ b/data/ui/dither_page.blp
@@ -3,7 +3,7 @@ using Adw 1;
 
 template $HalftoneDitherPage: Adw.BreakpointBin {
   width-request: 360;
-  height-request: 360;
+  height-request: 296;
 
   child: Adw.OverlaySplitView split_view {
     sidebar-position: start;
@@ -27,45 +27,55 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
         }
 
         [end]
-        Gtk.MenuButton {
+        Gtk.MenuButton sidebar_main_menu {
           tooltip-text: _("Main Menu");
           icon-name: "open-menu-symbolic";
           menu-model: main_menu;
 
-          primary: bind split_view.show-sidebar;
+          primary: true;
         }
       }
     };
 
     content: Adw.ToolbarView dither_view {
+      extend-content-to-top-edge: true;
+
       [top]
-      Adw.HeaderBar {
-        centering-policy: strict;
-        show-title: false;
+      Gtk.Stack dither_header_stack {
+        Gtk.StackPage {
+          name: "desktop";
 
-        styles [
-          "flat"
-        ]
+          child: Adw.HeaderBar {
+            show-title: false;
 
-        [start]
-        Gtk.Button content_open_button {
-          tooltip-text: _("Open Image (Ctrl+O)");
-          icon-name: "arrow-into-box-symbolic";
-          action-name: "app.open-image";
-
-          visible: bind split_view.show-sidebar inverted;
+            styles [
+              "desktop"
+            ]
+          };
         }
 
-        [end]
-        Gtk.MenuButton content_main_menu {
-          tooltip-text: _("Main Menu");
-          icon-name: "open-menu-symbolic";
-          menu-model: main_menu;
+        Gtk.StackPage {
+          name: "mobile";
 
-          primary: bind split_view.show-sidebar inverted;
-          visible: bind split_view.show-sidebar inverted;
+          child: Adw.HeaderBar {
+              [start]
+              Gtk.Button content_open_button {
+                tooltip-text: _("Open Image (Ctrl+O)");
+                icon-name: "arrow-into-box-symbolic";
+                action-name: "app.open-image";
+              }
+
+              [end]
+              Gtk.MenuButton content_main_menu {
+                tooltip-text: _("Main Menu");
+                icon-name: "open-menu-symbolic";
+                menu-model: main_menu;
+              }
+            };
+          }
+
+          visible-child-name: "desktop";
         }
-      }
 
       content: Gtk.Box image_box {
         orientation: vertical;
@@ -74,6 +84,7 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
         hexpand: true;
 
         Gtk.Stack preview_group_stack {
+          height-request: 150;
           transition-type: crossfade;
 
           Gtk.StackPage {
@@ -89,43 +100,37 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
                   can-shrink: false;
                   halign: center;
                   valign: center;
-
-                  styles [
-                    "card"
-                  ]
                 }
               };
 
               [overlay]
-              Gtk.Box {
+              Gtk.Button toggle_sheet_button {
+                halign: start;
+                valign: end;
+                icon-name: "sidebar-show-left-symbolic";
+                action-name: "app.toggle-sheet";
+                tooltip-text: _("Toggle Sidebar");
+
+                styles [
+                  "osd",
+                  "circular",
+                  "custom-on-image"
+                ]
+              }
+
+              [overlay]
+              Gtk.Button {
                 halign: end;
                 valign: end;
-                margin-end: 12;
-                margin-bottom: 12;
-                orientation: horizontal;
-                spacing: 10;
+                icon-name: "adw-external-link-symbolic";
+                tooltip-text: _("Open in External Image Viewer");
+                action-name: "app.show-preview-image";
 
-                Gtk.Button toggle_sheet_button {
-                  icon-name: "sidebar-show-left-symbolic";
-                  tooltip-text: _("Toggle Sidebar");
-                  action-name: "app.toggle-sheet";
-
-                  styles [
-                    "osd",
-                    "circular"
-                  ]
-                }
-
-                Gtk.Button {
-                  icon-name: "adw-external-link-symbolic";
-                  tooltip-text: _("Open in External Image Viewer");
-                  action-name: "app.show-preview-image";
-
-                  styles [
-                    "osd",
-                    "circular"
-                  ]
-                }
+                styles [
+                  "osd",
+                  "circular",
+                  "custom-on-image"
+                ]
               }
             };
           }
@@ -146,8 +151,10 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
 
         // TODO: Add SpringAnimation to animate sheet hiding
         // TODO: Add scroll and touch drag gestures for triggering bottom sheet hide animation
+
         Gtk.Box bottom_sheet_box {
           orientation: vertical;
+          valign: end;
           visible: false;
 
           Gtk.Separator {
@@ -163,15 +170,22 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
   Adw.Breakpoint mobile_breakpoint {
     condition ("max-width: 640px")
     setters {
+      sidebar_main_menu.primary: false;
+      content_main_menu.primary: true;
       split_view.collapsed: true;
+      dither_view.extend-content-to-top-edge: false;
+      dither_view.top-bar-style: raised_border;
+      dither_header_stack.visible-child-name: "mobile";
+      toggle_sheet_button.icon-name: "sheet-show-bottom-symbolic";
+      toggle_sheet_button.tooltip-text: _("Toggle Bottom Sheet");
       bottom_sheet_box.visible: true;
     }
   }
 }
 
 Adw.Bin image_prefs_bin {
-  child: Gtk.Overlay {
-    child: Adw.PreferencesPage {
+  child: Adw.ToolbarView {
+    Adw.PreferencesPage {
       Adw.PreferencesGroup options_group {
         title: _("Options");
 
@@ -290,32 +304,13 @@ Adw.Bin image_prefs_bin {
           model: Gtk.StringList image_formats_stringlist {};
         }
       }
+    }
 
-      Adw.PreferencesGroup bottom_margin_group {
-        margin-bottom: 46;
-      }
-    };
-
-    [overlay]
-    Gtk.Box result_overlay {
-      orientation: horizontal;
-      margin-bottom: 24;
+    [bottom]
+    Gtk.Box {
       halign: center;
-      vexpand: true;
-      valign: end;
-      spacing: 6;
-
-      Gtk.Button more_options_button {
-        visible: false;
-        label: _("More Options");
-
-        styles [
-          "pill"
-        ]
-      }
-
       Gtk.Button save_image_button {
-        label: _("Dither It!");
+        label: _("Save Image");
         action-name: "app.save-image";
 
         styles [
@@ -323,50 +318,38 @@ Adw.Bin image_prefs_bin {
           "suggested-action"
         ]
       }
+
+      styles [
+        "sheet-toolbar"
+      ]
     }
   };
 }
 
 Gtk.Popover options_information_popover {
-  autohide: true;
-
-  Gtk.Box {
-    orientation: vertical;
+  Gtk.Label {
     margin-top: 6;
     margin-bottom: 6;
     margin-start: 6;
     margin-end: 6;
-
-    Gtk.Label {
-      wrap: true;
-      justify: center;
-      max-width-chars: 40;
-      label: _("You can customize some of these parameters to make your image look different. To learn more about individual options, go to the wiki page.");
-    }
-
-    Gtk.LinkButton {
-      label: _("Wiki Page");
-      uri: "https://github.com/tfuxu/Halftone/wiki/Options";
-    }
+    wrap: true;
+    justify: center;
+    max-width-chars: 30;
+    use-markup: true;
+    label:  _("To learn more about individual options, go to the <a href=\"https://github.com/tfuxu/Halftone/wiki/Options\">wiki page</a>.");
   }
 }
 
 Gtk.Popover aspect_ratio_popover {
-  autohide: true;
-
-  Gtk.Box {
-    orientation: vertical;
-    margin-top: 6;
-    margin-bottom: 6;
-    margin-start: 6;
-    margin-end: 6;
-
-    Gtk.Label {
-      wrap: true;
-      justify: center;
-      max-width-chars: 40;
-      label: _("This option allowes you to preserve original aspect ratio when resizing an image.");
-    }
+  Gtk.Label {
+    margin-top: 3;
+    margin-bottom: 3;
+    margin-start: 3;
+    margin-end: 3;
+    wrap: true;
+    justify: center;
+    max-width-chars: 30;
+    label: _("This option allows you to preserve original aspect ratio when resizing an image.");
   }
 }
 

--- a/data/ui/dither_page.blp
+++ b/data/ui/dither_page.blp
@@ -31,7 +31,6 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
           tooltip-text: _("Main Menu");
           icon-name: "open-menu-symbolic";
           menu-model: main_menu;
-
           primary: true;
         }
       }
@@ -58,24 +57,24 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
           name: "mobile";
 
           child: Adw.HeaderBar {
-              [start]
-              Gtk.Button content_open_button {
-                tooltip-text: _("Open Image (Ctrl+O)");
-                icon-name: "arrow-into-box-symbolic";
-                action-name: "app.open-image";
-              }
+            [start]
+            Gtk.Button content_open_button {
+              tooltip-text: _("Open Image (Ctrl+O)");
+              icon-name: "arrow-into-box-symbolic";
+              action-name: "app.open-image";
+            }
 
-              [end]
-              Gtk.MenuButton content_main_menu {
-                tooltip-text: _("Main Menu");
-                icon-name: "open-menu-symbolic";
-                menu-model: main_menu;
-              }
-            };
-          }
-
-          visible-child-name: "desktop";
+            [end]
+            Gtk.MenuButton content_main_menu {
+              tooltip-text: _("Main Menu");
+              icon-name: "open-menu-symbolic";
+              menu-model: main_menu;
+            }
+          };
         }
+
+        visible-child-name: "desktop";
+      }
 
       content: Gtk.Box image_box {
         orientation: vertical;
@@ -185,7 +184,7 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
 
 Adw.Bin image_prefs_bin {
   child: Adw.ToolbarView {
-    Adw.PreferencesPage {
+    content: Adw.PreferencesPage {
       Adw.PreferencesGroup options_group {
         title: _("Options");
 
@@ -304,7 +303,7 @@ Adw.Bin image_prefs_bin {
           model: Gtk.StringList image_formats_stringlist {};
         }
       }
-    }
+    };
 
     [bottom]
     Gtk.Box {
@@ -336,7 +335,7 @@ Gtk.Popover options_information_popover {
     justify: center;
     max-width-chars: 30;
     use-markup: true;
-    label:  _("To learn more about individual options, go to the <a href=\"https://github.com/tfuxu/Halftone/wiki/Options\">wiki page</a>.");
+    label: _("To learn more about individual options, go to the <a href=\"https://github.com/tfuxu/Halftone/wiki/Options\">wiki page</a>.");
   }
 }
 

--- a/data/ui/main_window.blp
+++ b/data/ui/main_window.blp
@@ -52,11 +52,7 @@ template $HalftoneMainWindow: Adw.ApplicationWindow {
                 halign: center;
                 clicked => $on_open_image();
 
-                Adw.ButtonContent {
-                  icon-name: "arrow-into-box-symbolic";
-                  label: _("Open Image");
-                  use-underline: true;
-                }
+                label: _("Open Image");
 
                 styles [
                   "suggested-action",

--- a/halftone/views/about_window.py
+++ b/halftone/views/about_window.py
@@ -24,6 +24,7 @@ class HalftoneAboutWindow:
             issue_url=constants.bugtracker_url,
             developers=[
                 "tfuxu https://github.com/tfuxu",
+                "Brage Fuglseth https://bragefuglseth.dev",
             ],
             designers=[
                 "tfuxu https://github.com/tfuxu",

--- a/halftone/views/dither_page.py
+++ b/halftone/views/dither_page.py
@@ -397,17 +397,11 @@ class HalftoneDitherPage(Adw.BreakpointBin):
 
         self.is_mobile = True
 
-        self.toggle_sheet_button.set_tooltip_text(_("Toggle Bottom Sheet"))
-        self.toggle_sheet_button.set_icon_name("sheet-show-bottom-symbolic")
-
     def on_breakpoint_unapply(self, *args):
         self.bottom_sheet.set_child(None)
         self.sidebar_view.set_content(self.image_prefs_bin)
 
         self.is_mobile = False
-
-        self.toggle_sheet_button.set_tooltip_text(_("Toggle Sidebar"))
-        self.toggle_sheet_button.set_icon_name("sidebar-show-right-symbolic")
 
     """ Module-specific helpers """
 


### PR DESCRIPTION
Various changes to the UI to make it more elegant and robust. There are too many small ones to list here, so read through all of the changed code to see if there's anything you want to be different, but the most significant tweaks are:

- Making the image extend all the way to the top of the window in desktop mode
- Changing the "Dither It!" label into "Save Image" (I know, less fun, but it makes a lot more sense workflow-wise, as the dithered image is already visible)
- Moving the mentioned button into a bottom toolbar to avoid clutter
- Moving more properties into the breakpoint instead of setting them with bindings, to make things more tidy and concentrate adaptive properties in one place

![Skjermbilde fra 2024-01-06 22-08-06](https://github.com/tfuxu/Halftone/assets/91388039/1242564f-8bed-46ad-b433-58d1ead9a0e3)

Please let me know if you want anything changed!