### PR TITLE
Libadwaita 1.5 updates

### DIFF
--- a/build-aux/flatpak/io.github.tfuxu.Halftone.json
+++ b/build-aux/flatpak/io.github.tfuxu.Halftone.json
@@ -1,7 +1,7 @@
 {
   "app-id" : "io.github.tfuxu.Halftone",
   "runtime" : "org.gnome.Platform",
-  "runtime-version" : "45",
+  "runtime-version" : "46",
   "sdk" : "org.gnome.Sdk",
   "command" : "halftone",
   "finish-args" : [
@@ -34,7 +34,7 @@
               {
                   "type" : "git",
                   "url" : "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                  "tag" : "v0.10.0"
+                  "tag" : "v0.12.0"
               }
           ]
       },
@@ -49,7 +49,7 @@
           {
             "type": "git",
             "url": "https://github.com/ImageMagick/ImageMagick.git",
-            "tag": "7.1.1-21"
+            "tag": "7.1.1-29"
           }
         ]
       },

--- a/halftone/views/about_window.py
+++ b/halftone/views/about_window.py
@@ -1,4 +1,4 @@
-# Copyright 2023, tfuxu <https://github.com/tfuxu>
+# Copyright 2023-2024, tfuxu <https://github.com/tfuxu>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from gi.repository import Gtk, Adw
@@ -14,9 +14,8 @@ class HalftoneAboutWindow:
         self.setup()
 
     def setup(self):
-        self.about_window = Adw.AboutWindow(
+        self.about_window = Adw.AboutDialog(
             application_name="Halftone",
-            transient_for=self.app.get_active_window(),
             application_icon=constants.app_id,
             developer_name="tfuxu",
             website=constants.project_url,
@@ -39,4 +38,4 @@ class HalftoneAboutWindow:
         )
 
     def show_about(self):
-        self.about_window.present()
+        self.about_window.present(self.parent)

--- a/local.sh
+++ b/local.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/bash
 
 # Copyright (C) 2022-2023, Gradience Team
-# Copyright 2023, tfuxu <https://github.com/tfuxu>
+# Copyright 2023-2024, tfuxu <https://github.com/tfuxu>
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 read -p "Do you want to install Python requirements? [N/y] " answer
 
 if [[ "$answer" == "y" ]]; then
-    pip3 install -r requirements.txt
+    pip3 install -r requirements-dev.txt
 elif [[ "$answer" == "n" || "$answer" == "" ]]; then
     echo "Skipping requirements installation"
 fi

--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,8 @@
 project('halftone',
           version: '0.6.0',
     meson_version: '>= 0.59.0',
-  default_options: [ 'warning_level=2',
-                     'werror=false',
+  default_options: ['warning_level=2',
+                    'werror=false',
                    ],
 )
 
@@ -45,9 +45,9 @@ endif
 
 # Required dependencies
 dependency('glib-2.0')
-dependency('gtk4', version: '>= 4.5.0')
-dependency('libadwaita-1', version: '>= 1.2.0')
-dependency('pygobject-3.0', version: '>= 3.42.0')
+dependency('gtk4', version: '>= 4.12.0')
+dependency('libadwaita-1', version: '>= 1.5.0')
+dependency('pygobject-3.0', version: '>= 3.48.0')
 
 # Python installation directory
 PY_INSTALLDIR = python.find_installation('python3')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 
 pycairo
 pygobject
+pygobject-stubs


### PR DESCRIPTION
- Update to `46` runtime
- Use `Adw.AboutDialog` for about window
- Update `blueprint` to 0.12.0 and `ImageMagick` to `7.1.1-29`
- Bump required dependency versions in Meson configuration
- Add `pygobject-stubs` to `requirements-dev`
- Use `requirements-dev` when asked to install dependencies in `local.sh` script