### PR TITLE
Add new loading overlay for dithering process

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -25,3 +25,7 @@ headerbar.desktop windowcontrols button:active image {
 .sheet-toolbar {
     padding: 12px;
 }
+
+.preview-loading-blur {
+    filter: blur(6px);
+}

--- a/data/ui/dither_page.blp
+++ b/data/ui/dither_page.blp
@@ -82,69 +82,81 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
         vexpand: true;
         hexpand: true;
 
-        Gtk.Stack preview_group_stack {
-          height-request: 150;
-          transition-type: crossfade;
+        Gtk.Overlay {
+          child: Gtk.Overlay {
+            child: Gtk.ScrolledWindow preview_scroll_window {
+              vexpand: true;
+              hexpand: true;
 
-          Gtk.StackPage {
-            name: "preview_stack_main_page";
-
-            child: Gtk.Overlay {
-              child: Gtk.ScrolledWindow preview_scroll_window {
-                vexpand: true;
-                hexpand: true;
-
-                Gtk.Picture image_dithered {
-                  content-fit: cover;
-                  can-shrink: false;
-                  halign: center;
-                  valign: center;
-                }
-              };
-
-              [overlay]
-              Gtk.Button toggle_sheet_button {
-                halign: start;
-                valign: end;
-                icon-name: "sidebar-show-left-symbolic";
-                action-name: "app.toggle-sheet";
-                tooltip-text: _("Toggle Sidebar");
-
-                styles [
-                  "osd",
-                  "circular",
-                  "custom-on-image"
-                ]
-              }
-
-              [overlay]
-              Gtk.Button {
-                halign: end;
-                valign: end;
-                icon-name: "adw-external-link-symbolic";
-                tooltip-text: _("Open in External Image Viewer");
-                action-name: "app.show-preview-image";
-
-                styles [
-                  "osd",
-                  "circular",
-                  "custom-on-image"
-                ]
+              Gtk.Picture image_dithered {
+                content-fit: cover;
+                can-shrink: false;
+                halign: center;
+                valign: center;
               }
             };
-          }
 
-          Gtk.StackPage {
-            name: "preview_stack_loading_page";
+            [overlay]
+            Gtk.Button toggle_sheet_button {
+              halign: start;
+              valign: end;
+              icon-name: "sidebar-show-left-symbolic";
+              action-name: "app.toggle-sheet";
+              tooltip-text: _("Toggle Sidebar");
 
-            child: Gtk.Box {
+              styles [
+                "osd",
+                "circular",
+                "custom-on-image"
+              ]
+            }
+
+            [overlay]
+            Gtk.Button {
+              halign: end;
+              valign: end;
+              icon-name: "adw-external-link-symbolic";
+              tooltip-text: _("Open in External Image Viewer");
+              action-name: "app.show-preview-image";
+
+              styles [
+                "osd",
+                "circular",
+                "custom-on-image"
+              ]
+            }
+          };
+
+          [overlay]
+          Gtk.Box preview_loading_overlay {
+            vexpand: true;
+            hexpand: true;
+            orientation: vertical;
+            visible: false;
+
+            Gtk.Box {
+              vexpand: true;
+              hexpand: true;
               valign: center;
               halign: center;
+              spacing: 10;
+              orientation: vertical;
 
               Gtk.Spinner {
+                height-request: 64;
+                width-request: 64;
+
                 spinning: true;
               }
-            };
+
+              Gtk.Label {
+                label: _("Dithering your image…");
+              }
+            }
+
+            styles [
+              "osd"
+            ]
           }
         }
 

--- a/halftone/views/dither_page.py
+++ b/halftone/views/dither_page.py
@@ -175,9 +175,13 @@ class HalftoneDitherPage(Adw.BreakpointBin):
     """ Main functions """
 
     def update_preview_image(self, path: str, output_options: OutputOptions,
-                                callback: callable = None):
+                                   run_delay: bool = True, callback: callable = None):
         self.is_image_ready = False
-        GLib.timeout_add(self.loading_overlay_delay, self.on_awaiting_image_load)
+
+        if run_delay:
+            GLib.timeout_add(self.loading_overlay_delay, self.on_awaiting_image_load)
+        else:
+            self.on_awaiting_image_load()
 
         if self.preview_image_path:
             self.clean_preview_paintable()
@@ -200,6 +204,7 @@ class HalftoneDitherPage(Adw.BreakpointBin):
     # NOTE: Use this only if you initially load the picture (eg. from file chooser)
     def load_preview_image(self, file: Gio.File):
         self.input_image_path = file.get_path()
+
         try:
             self.set_original_paintable(self.input_image_path)
         except GLib.GError:
@@ -208,13 +213,15 @@ class HalftoneDitherPage(Adw.BreakpointBin):
 
         self.set_size_spins(self.original_paintable.get_width(),
                             self.original_paintable.get_height())
+
         self.start_task(self.update_preview_image,
                         self.input_image_path,
                         self.output_options,
+                        False,
                         self.on_successful_image_load)
 
     def save_image(self, paintable: Gdk.Paintable, output_path: str,
-                        output_options: OutputOptions, callback: callable):
+                         output_options: OutputOptions, callback: callable):
         self.win.show_loading_page()
 
         image_bytes = paintable.save_to_tiff_bytes()
@@ -248,6 +255,7 @@ class HalftoneDitherPage(Adw.BreakpointBin):
             self.start_task(self.update_preview_image,
                             self.input_image_path,
                             self.output_options,
+                            True,
                             self.on_successful_image_load)
 
     @Gtk.Template.Callback()
@@ -262,6 +270,7 @@ class HalftoneDitherPage(Adw.BreakpointBin):
         self.start_task(self.update_preview_image,
                         self.input_image_path,
                         self.output_options,
+                        True,
                         self.on_successful_image_load)
 
     @Gtk.Template.Callback()
@@ -276,6 +285,7 @@ class HalftoneDitherPage(Adw.BreakpointBin):
         self.start_task(self.update_preview_image,
                         self.input_image_path,
                         self.output_options,
+                        True,
                         self.on_successful_image_load)
 
     @Gtk.Template.Callback()
@@ -299,6 +309,7 @@ class HalftoneDitherPage(Adw.BreakpointBin):
             self.start_task(self.update_preview_image,
                             self.input_image_path,
                             self.output_options,
+                            True,
                             self.on_successful_image_load)
 
     @Gtk.Template.Callback()
@@ -315,6 +326,7 @@ class HalftoneDitherPage(Adw.BreakpointBin):
                 self.start_task(self.update_preview_image,
                                 self.input_image_path,
                                 self.output_options,
+                                True,
                                 self.on_successful_image_load)
 
     def on_save_image(self, *args):
@@ -375,6 +387,7 @@ class HalftoneDitherPage(Adw.BreakpointBin):
             self.start_task(self.update_preview_image,
                             self.input_image_path,
                             self.output_options,
+                            True,
                             self.on_successful_image_load)
 
     def on_save_format_selected(self, widget, *args):

--- a/halftone/views/dither_page.py
+++ b/halftone/views/dither_page.py
@@ -188,8 +188,6 @@ class HalftoneDitherPage(Adw.BreakpointBin):
             self.win.show_error_page()
             raise
 
-        self.image_dithered.set_paintable(self.updated_paintable)
-
         if callback:
             callback()
 
@@ -413,6 +411,8 @@ class HalftoneDitherPage(Adw.BreakpointBin):
             self.win.latest_traceback = logging.get_traceback(e)
             raise
 
+        self.image_dithered.set_paintable(self.original_paintable)
+
     def set_updated_paintable(self, path: str):
         try:
             self.updated_paintable = Gdk.Texture.new_from_filename(path)
@@ -422,6 +422,8 @@ class HalftoneDitherPage(Adw.BreakpointBin):
                 exc=e, show_exception=True)
             self.win.latest_traceback = logging.get_traceback(e)
             raise
+
+        self.image_dithered.set_paintable(self.updated_paintable)
 
     def clean_preview_paintable(self):
         try:

--- a/halftone/views/dither_page.py
+++ b/halftone/views/dither_page.py
@@ -57,7 +57,7 @@ class HalftoneDitherPage(Adw.BreakpointBin):
     save_image_chooser = Gtk.Template.Child()
     all_filter = Gtk.Template.Child()
 
-    preview_group_stack = Gtk.Template.Child()
+    preview_loading_overlay = Gtk.Template.Child()
 
     mobile_breakpoint = Gtk.Template.Child()
 
@@ -117,9 +117,6 @@ class HalftoneDitherPage(Adw.BreakpointBin):
             self.update_preview_content_fit)
 
     def setup(self):
-        # Set default preview stack child
-        self.preview_group_stack.set_visible_child_name("preview_stack_loading_page")
-
         # Set utility page in sidebar by default
         self.sidebar_view.set_content(self.image_prefs_bin)
 
@@ -192,7 +189,6 @@ class HalftoneDitherPage(Adw.BreakpointBin):
             raise
 
         self.image_dithered.set_paintable(self.updated_paintable)
-        self.on_successful_image_load()
 
         if callback:
             callback()
@@ -384,11 +380,13 @@ class HalftoneDitherPage(Adw.BreakpointBin):
         self.output_options.output_format = format_string
 
     def on_successful_image_load(self, *args):
-        self.preview_group_stack.set_visible_child_name("preview_stack_main_page")
+        self.preview_loading_overlay.set_visible(False)
+        self.image_dithered.remove_css_class("preview-loading-blur")
         self.save_image_button.set_sensitive(True)
 
     def on_awaiting_image_load(self, *args):
-        self.preview_group_stack.set_visible_child_name("preview_stack_loading_page")
+        self.preview_loading_overlay.set_visible(True)
+        self.image_dithered.add_css_class("preview-loading-blur")
         self.save_image_button.set_sensitive(False)
 
     def on_breakpoint_apply(self, *args):


### PR DESCRIPTION
This PR adds a new, better looking loading screen for dithering process. 
~This is supposed to fix #65, but as of now, I've yet to implement the timeout mechanism, that will show loading screen only when dithering operation takes more than 3 seconds.~ Implemented in 75d817b253ed7b3430e32770d024d6a32f9119c8

See it in action [here](https://github.com/tfuxu/Halftone/assets/73042332/d5d16845-8872-412a-9e83-0af05697d6d0).