### PR TITLE
Add Norwegian Bokmål translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -9,3 +9,4 @@ tr
 sk
 uk
 zh_CN
+nb

--- a/po/nb.po
+++ b/po/nb.po
@@ -1,0 +1,357 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the halftone package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: halftone\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-04-04 19:03+0200\n"
+"PO-Revision-Date: 2024-09-23 09:37+0200\n"
+"Last-Translator: Sunniva Løvstad <turtle@turtle.garden>\n"
+"Language-Team: \n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.4\n"
+
+#. Translators: Application name. Keep this string as "Halftone"
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:4
+#: data/io.github.tfuxu.Halftone.desktop.in.in:4
+msgid "Halftone"
+msgstr "Halvtone"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:5
+#: data/io.github.tfuxu.Halftone.desktop.in.in:9 data/ui/main_window.blp:42
+msgid "Dither your images"
+msgstr "Dither bildene dine"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:17
+msgid ""
+"A simple Libadwaita app for lossy image compression using dithering "
+"technique. Give your images a pixel art-like style and reduce the file size "
+"in the process with Halftone."
+msgstr ""
+"En enkel libadwaita-app for destruktiv bildekomprimering med dithering. Gi "
+"bildene dine en pikselkunstaktig stil og reduser filstørrelsen samtidig med "
+"Halvtone."
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:76
+msgid "Updated widgets to make use of new Libadwaita 1.5 widgets"
+msgstr "Oppdaterte widgetene for å bruke nye libadwaita 1.5-widgeter"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:77
+msgid "Updated translations for Russian, Turkish and Simplified Chinese"
+msgstr "Oppdaterte oversettingene til russisk, tyrkisk, og forenklet kinesisk"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:83
+msgid ""
+"Another major UI design update! This update notably moves sidebar to the "
+"left and makes image preview area extra large, by making headerbar "
+"transparent."
+msgstr ""
+"En til stor grensesnittsoppdatering! Denne oppdateringen flytter nemlig "
+"sidefeltet til den venstre siden og gjør bildeforhåndsvisningsområdet "
+"ekstra stor ved å gjøre hovedlinjen gjennomsiktig."
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:88
+msgid "Changes:"
+msgstr "Endringer:"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:90
+msgid "Implement UI suggestions from GNOME Circle application"
+msgstr "Ta i bruk grensesnittsanbefalinger fra GNOME Circle-applikasjonen"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:91
+msgid "Add keyboard shortcuts for toggling sidebar and main menu"
+msgstr ""
+"Legg til tastatursnarveier for å vise/skjule sidefeltet og hovedmenyen"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:92
+msgid ""
+"Fixed formatting in appdata, now release info should finally show up in "
+"Flathub!"
+msgstr "Fikset formatering i appdata, nå skal utgaveinfo vises i Flathub!"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:93
+msgid "Updated translations"
+msgstr "Oppdaterte oversettinger"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:100
+msgid "Bottom options sheet for mobile users"
+msgstr "Innstillingsområde på bunnsiden for mobilbrukere"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:101
+msgid "Fix main window not being able to resize width down to 360px"
+msgstr "Fiks hovedvindu: nå kan størrelsen endres til 360px"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:102
+msgid "Load image options from previous image to next loaded image"
+msgstr "Behold bildeinnstillinger fra forrige bilde til neste innlastet bilde"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:103
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:112
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:121
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:133
+msgid "New translations"
+msgstr "Nye oversettinger"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:110
+msgid "New refreshed user interface"
+msgstr "Nytt oppdatert grensesnitt"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:111
+msgid ""
+"Fix issue with \"Open in External Image Viewer\" button not working on "
+"Flatpak builds"
+msgstr ""
+"Fiks feil med at «Åpne med ekstern bildeviser» fungerte ikke på Flatpak-"
+"versjonen"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:119
+msgid ""
+"Added option to change how image should be resized to fit inside preview box"
+msgstr ""
+"La til alternative for å endre hvordan bildet bør justeres for å passe inn "
+"i forhåndsvisningsområdet"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:120
+msgid "Now Halftone uses flat headerbar style"
+msgstr "Ny Halvtone bruker en flat hovedlinje"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:128
+msgid "Added brightness and contrast control"
+msgstr "La til lysstyrke- og kontrastkontroller"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:129
+msgid "Added button for opening preview image in external image viewers"
+msgstr "La til knapp for å åpne forhåndsvisningsbilde i eksterne bildevisere"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:130
+msgid "Added custom logging facility for easier issue reporting"
+msgstr "La til tilpasset logging for forenkling av feilrapportering"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:131
+msgid "Added logic code to \"Copy Logs\" button"
+msgstr "La til kode til knappen «Kopier logger»"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:132
+msgid "Moved image size option to Image Properties"
+msgstr "Flyttet alternativet for bildestørrelse til Bildeegenskaper"
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:139
+msgid "Renamed Pixely to Halftone."
+msgstr "Ga Pixely nytt navn: nå er appen Halvton."
+
+#: data/io.github.tfuxu.Halftone.metainfo.xml.in.in:144
+msgid "Initial release of Pixely."
+msgstr "Første utgave av Pixely."
+
+#. Translators: These are search terms to find this application. Do NOT translate or localize the semicolons. The list MUST also end with a semicolon.
+#: data/io.github.tfuxu.Halftone.desktop.in.in:13
+msgid "image;compression;pixelart;dither;processing;"
+msgstr "bilde;komprimering;pikselkonst;pixelart;dither:behandling;"
+
+#: data/ui/dither_page.blp:24 data/ui/dither_page.blp:62
+msgid "Open Image (Ctrl+O)"
+msgstr "Åpne bilde (Ctrl + O)"
+
+#: data/ui/dither_page.blp:31 data/ui/dither_page.blp:69
+msgid "Main Menu"
+msgstr "Hovedmeny"
+
+#: data/ui/dither_page.blp:111
+msgid "Toggle Sidebar"
+msgstr "Vis/skjul sidefelt"
+
+#: data/ui/dither_page.blp:125
+msgid "Open in External Image Viewer"
+msgstr "Åpne med ekstern bildeviser"
+
+#: data/ui/dither_page.blp:179
+msgid "Toggle Bottom Sheet"
+msgstr "Vis/skjul bunnområdet"
+
+#: data/ui/dither_page.blp:189
+msgid "Options"
+msgstr "Alternativer"
+
+#: data/ui/dither_page.blp:196 data/ui/dither_page.blp:281
+msgid "Explanation"
+msgstr "Forklaring"
+
+#: data/ui/dither_page.blp:204
+msgid "Dither Algorithm"
+msgstr "Dither-algoritme"
+
+#: data/ui/dither_page.blp:214
+msgid "Color Amount"
+msgstr "Fargemengde"
+
+#: data/ui/dither_page.blp:225
+msgid "Convert To"
+msgstr "Konverter til"
+
+#: data/ui/dither_page.blp:231
+msgid "Adjustments"
+msgstr "Justeringer"
+
+#: data/ui/dither_page.blp:234
+msgid "Brightness"
+msgstr "Lysstyrke"
+
+#: data/ui/dither_page.blp:235 data/ui/dither_page.blp:247
+msgid "Range -100 to 100"
+msgstr "Fra -100 til 100"
+
+#: data/ui/dither_page.blp:246
+msgid "Contrast"
+msgstr "Kontrast"
+
+#: data/ui/dither_page.blp:259
+msgid "Image Size"
+msgstr "Bildestørrelse"
+
+#: data/ui/dither_page.blp:262
+msgid "Width"
+msgstr "Bredde"
+
+#: data/ui/dither_page.blp:263 data/ui/dither_page.blp:291
+msgid "In pixels"
+msgstr "I piksler"
+
+#: data/ui/dither_page.blp:274
+msgid "Keep aspect ratio"
+msgstr "Behold sideforhold"
+
+#: data/ui/dither_page.blp:290
+msgid "Height"
+msgstr "Høyde"
+
+#: data/ui/dither_page.blp:307
+msgid "Save Image"
+msgstr "Lagre bilde"
+
+#: data/ui/dither_page.blp:333
+msgid ""
+"To learn more about individual options, go to the <a href=\"https://github."
+"com/tfuxu/Halftone/wiki/Options\">wiki page</a>."
+msgstr ""
+"For å lære mer om enkelte alternativer, besøk <a href=\"https://github.com/"
+"tfuxu/Halftone/wiki/Options\">wiki-siden</a>."
+
+#: data/ui/dither_page.blp:346
+msgid ""
+"This option allows you to preserve original aspect ratio when resizing an "
+"image."
+msgstr ""
+"Dette alternativet beholder det opprinnelige sideforholdet når du endrer "
+"størrelsen på et bilde."
+
+#: data/ui/dither_page.blp:351
+msgid "Save an Image in…"
+msgstr "Lagre bilde i…"
+
+#: data/ui/dither_page.blp:356 data/ui/main_window.blp:175
+msgid "All files"
+msgstr "Alle filer"
+
+#: data/ui/dither_page.blp:368
+msgid "Keyboard Shortcuts"
+msgstr "Tastatursnarveier"
+
+#: data/ui/dither_page.blp:373 data/ui/main_window.blp:30
+#: data/ui/main_window.blp:82 data/ui/main_window.blp:132
+msgid "About Halftone"
+msgstr "Om Halvtone"
+
+#: data/ui/help_overlay.blp:11
+msgctxt "shortcut window"
+msgid "Image"
+msgstr "Bilde"
+
+#: data/ui/help_overlay.blp:14
+msgctxt "shortcut window"
+msgid "Open Image"
+msgstr "Åpne bilde"
+
+#: data/ui/help_overlay.blp:19
+msgctxt "shortcut window"
+msgid "Save Image"
+msgstr "Lagre bilde"
+
+#: data/ui/help_overlay.blp:25
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Generelt"
+
+#: data/ui/help_overlay.blp:28
+msgctxt "shortcut window"
+msgid "Toggle Utility Pane"
+msgstr "Vis/skjul innstillingsområdet"
+
+#: data/ui/help_overlay.blp:33
+msgctxt "shortcut window"
+msgid "Show Shortcuts"
+msgstr "Vis tastatursnarveier"
+
+#: data/ui/help_overlay.blp:43
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Avslutt"
+
+#: data/ui/main_window.blp:55 halftone/views/dither_page.py:231
+msgid "Open Image"
+msgstr "Åpne bilde"
+
+#: data/ui/main_window.blp:109
+msgid "Drop Here to Load Image"
+msgstr "Slipp her for å laste inn bilde"
+
+#: data/ui/main_window.blp:145
+msgid "Image Error Occurred"
+msgstr "En feil har oppstått med bildet"
+
+#: data/ui/main_window.blp:146
+msgid ""
+"An error occurred while loading an image. If this error persists, please "
+"copy logs and report issue to the bug tracker."
+msgstr ""
+"En feil har oppstått under innlasting av bildet. Hvis denne feilen forblir, "
+"vennligst kopier loggene og rapporter feilen i GitHub."
+
+#: data/ui/main_window.blp:154
+msgid "Copy Logs"
+msgstr "Kopier logger"
+
+#: data/ui/main_window.blp:170
+msgid "Select an Image"
+msgstr "Velg et bilde"
+
+#. TRANSLATORS: This is a place to put your credits (formats: "Name https://example.com" or "Name <email@example.com>", no quotes) and is not meant to be translated literally.
+#: halftone/views/about_window.py:33
+msgid "translator-credits"
+msgstr "Sunniva Løvstad <halvtone@turtle.garden>"
+
+#: halftone/views/main_window.py:103
+msgid "Supported image formats"
+msgstr "Støttede bildeformater"
+
+#: halftone/views/main_window.py:123
+msgid "Failed to load an image"
+msgstr "En feil har oppstått ved innlasting av bildet"
+
+#: halftone/views/main_window.py:140
+msgid "Copied logs to clipboard"
+msgstr "Kopierte loggene til utklippstavlen"
+
+#: halftone/views/dither_page.py:230
+msgid "Image dithered successfully!"
+msgstr "Bilde har blitt ditheret!"
+
+#: halftone/views/dither_page.py:514
+msgid "Failed to load preview image"
+msgstr "Kunne ikke laste inn bildeforhåndsvisning"


### PR DESCRIPTION
This pull request adds a Norwegian Bokmål translation to Halftone.

Note before merging:

- The name of the app has been Norwegianised to *Halvtone*: if this is not preferred, I can revert this change.
- The verb *dither* has been directly translated (as there appears to be no Norwegian translation for this): if wanted I can derive a more Norwegian word for this, but I'm not sure if that would be beneficial.