### PR TITLE
Implement zoom for previews

### DIFF
--- a/data/io.github.tfuxu.Halftone.gschema.xml.in
+++ b/data/io.github.tfuxu.Halftone.gschema.xml.in
@@ -10,13 +10,5 @@
     <key name="window-maximized" type="b">
       <default>false</default>
     </key>
-    <!--<key name="preview-content-fit" type="i">
-      <range min="0" max="3"/>
-      Translators: Do not translate this description.
-      <description>
-        0 - FILL, 1 - CONTAIN, 2 - COVER, 3 - SCALE_DOWN
-      </description>
-      <default>2</default>
-    </key>-->
   </schema>
 </schemalist>

--- a/data/style.css
+++ b/data/style.css
@@ -1,9 +1,3 @@
-button.custom-on-image {
-  min-width: 42px;
-  min-height: 42px;
-  margin: 12px;
-}
-
 .dragndrop_overlay {
   background-color: alpha(var(--accent-bg-color), 0.5);
   color: var(--accent-fg-color);
@@ -28,4 +22,9 @@ headerbar.desktop windowcontrols button:active image {
 
 .preview-loading-blur {
     filter: blur(6px);
+}
+
+.image-viewer-fab {
+    min-width: 42px;
+    min-height: 42px;
 }

--- a/data/ui/dither_page.blp
+++ b/data/ui/dither_page.blp
@@ -152,21 +152,6 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
                 }
               }
             }
-
-            /*[overlay]
-            Gtk.Button {
-              halign: end;
-              valign: end;
-              icon-name: "adw-external-link-symbolic";
-              tooltip-text: _("Open in External Image Viewer");
-              action-name: "app.show-preview-image";
-
-              styles [
-                "osd",
-                "circular",
-                "custom-on-image"
-              ]
-            }*/
           };
 
           [overlay]

--- a/data/ui/dither_page.blp
+++ b/data/ui/dither_page.blp
@@ -217,6 +217,10 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
       bottom_sheet_box.visible: true;
     }
   }
+
+  Gtk.ShortcutController shortcut_controller {
+    scope: global;
+  }
 }
 
 Adw.Bin image_preferences_bin {

--- a/data/ui/dither_page.blp
+++ b/data/ui/dither_page.blp
@@ -86,11 +86,8 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
               vexpand: true;
               hexpand: true;
 
-              Gtk.Picture image_view {
-                content-fit: cover;
-                can-shrink: false;
-                halign: center;
-                valign: center;
+              Gtk.Viewport image_viewport {
+                scroll-to-focus: false;
               }
             };
 

--- a/data/ui/dither_page.blp
+++ b/data/ui/dither_page.blp
@@ -74,7 +74,7 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
         visible-child-name: "desktop";
       }
 
-      content: Gtk.Box image_box {
+      content: Gtk.Box preview_box {
         orientation: vertical;
         homogeneous: true;
         vexpand: true;
@@ -82,11 +82,11 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
 
         Gtk.Overlay {
           child: Gtk.Overlay {
-            child: Gtk.ScrolledWindow preview_scroll_window {
+            child: Gtk.ScrolledWindow scrolled_window {
               vexpand: true;
               hexpand: true;
 
-              Gtk.Picture image_dithered {
+              Gtk.Picture image_view {
                 content-fit: cover;
                 can-shrink: false;
                 halign: center;
@@ -190,7 +190,7 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
   }
 }
 
-Adw.Bin image_prefs_bin {
+Adw.Bin image_preferences_bin {
   child: Adw.ToolbarView {
     content: Adw.PreferencesPage {
       Adw.PreferencesGroup options_group {
@@ -365,7 +365,7 @@ Gtk.FileDialog save_image_dialog {
   modal: true;
 }
 
-Gtk.FileFilter all_filter {
+Gtk.FileFilter all_files_filter {
   name: _("All files");
   mime-types ["application/octet-stream"]
 }

--- a/data/ui/dither_page.blp
+++ b/data/ui/dither_page.blp
@@ -210,7 +210,9 @@ Adw.Bin image_preferences_bin {
 
         Adw.ComboRow dither_algorithms_combo {
           title: _("Dither Algorithm");
-          model: Gtk.StringList algorithms_stringlist {};
+          model: Gtk.StringList algorithms_stringlist {
+            strings ["Floyd-Steinberg", "Riemersma", "Bayer (ordered)"]
+          };
         }
 
         //Adw.ComboRow color_palette {

--- a/data/ui/dither_page.blp
+++ b/data/ui/dither_page.blp
@@ -92,21 +92,68 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
             };
 
             [overlay]
-            Gtk.Button toggle_sheet_button {
-              halign: start;
+            Gtk.Box toggle_sheet_box {
               valign: end;
-              icon-name: "sidebar-show-left-symbolic";
-              action-name: "app.toggle-sheet";
-              tooltip-text: _("Toggle Sidebar");
+              halign: start;
+              margin-start: 18;
+              margin-bottom: 18;
 
-              styles [
-                "osd",
-                "circular",
-                "custom-on-image"
-              ]
+              Gtk.Box {
+                orientation: horizontal;
+                spacing: 12;
+
+                Gtk.Button toggle_sheet_button {
+                  icon-name: "sidebar-show-left-symbolic";
+                  tooltip-text: _("Toggle Sidebar");
+                  action-name: "app.toggle-sheet";
+
+                  styles [
+                    "osd",
+                    "image-viewer-fab",
+                    "circular"
+                  ]
+                }
+              }
             }
 
             [overlay]
+            Gtk.Box zoom_box {
+              valign: end;
+              halign: end;
+              margin-end: 18;
+              margin-bottom: 18;
+
+              Gtk.Box {
+                orientation: horizontal;
+                spacing: 12;
+
+                Gtk.Button zoom_out_button {
+                  icon-name: "zoom-out-symbolic";
+                  tooltip-text: _("Zoom Out");
+                  action-name: "zoom.out";
+
+                  styles [
+                    "osd",
+                    "image-viewer-fab",
+                    "circular"
+                  ]
+                }
+
+                Gtk.Button zoom_in_button {
+                  icon-name: "zoom-in-symbolic";
+                  tooltip-text: _("Zoom In");
+                  action-name: "zoom.in";
+
+                  styles [
+                    "osd",
+                    "image-viewer-fab",
+                    "circular"
+                  ]
+                }
+              }
+            }
+
+            /*[overlay]
             Gtk.Button {
               halign: end;
               valign: end;
@@ -119,7 +166,7 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
                 "circular",
                 "custom-on-image"
               ]
-            }
+            }*/
           };
 
           [overlay]

--- a/data/ui/help_overlay.blp
+++ b/data/ui/help_overlay.blp
@@ -19,6 +19,16 @@ ShortcutsWindow help_overlay {
         title: C_("shortcut window", "Save Image");
         action-name: "app.save-image";
       }
+
+      ShortcutsShortcut {
+        title: C_("shortcut window", "Zoom In");
+        accelerator: "<Ctrl>plus plus";
+      }
+
+      ShortcutsShortcut {
+        title: C_("shortcut window", "Zoom Out");
+        accelerator: "<Ctrl>minus minus";
+      }
     }
 
     ShortcutsGroup {
@@ -27,6 +37,11 @@ ShortcutsWindow help_overlay {
       ShortcutsShortcut {
         title: C_("shortcut window", "Toggle Utility Pane");
         action-name: "app.toggle-sheet";
+      }
+
+      ShortcutsShortcut {
+        title: C_("shortcut window", "Show Main Menu");
+        accelerator: "F10";
       }
 
       ShortcutsShortcut {
@@ -42,6 +57,20 @@ ShortcutsWindow help_overlay {
       ShortcutsShortcut {
         title: C_("shortcut window", "Quit");
         action-name: "app.quit";
+      }
+    }
+
+    ShortcutsGroup {
+      title: C_("shortcut window", "Gestures");
+
+      ShortcutsShortcut {
+        title: C_("shortcut window", "Zoom In");
+        shortcut-type: gesture_stretch;
+      }
+
+      ShortcutsShortcut {
+        title: C_("shortcut window", "Zoom Out");
+        shortcut-type: gesture_pinch;
       }
     }
   }

--- a/halftone/backend/utils/temp.py
+++ b/halftone/backend/utils/temp.py
@@ -37,7 +37,7 @@ class HalftoneTempFile:
         :rtype: :class:`None`
         """
 
-        if not isinstance(path, (str, bytes)):
+        if not path:
             return
 
         temp_file = Path(path)

--- a/halftone/main.py
+++ b/halftone/main.py
@@ -58,10 +58,6 @@ class HalftoneApplication(Adw.Application):
         show_image_external_action.connect('activate', self.show_image_external)
         self.add_action(show_image_external_action)
 
-        show_preview_image_action = Gio.SimpleAction.new('show-preview-image', None)
-        show_preview_image_action.connect('activate', self.show_preview_image)
-        self.add_action(show_preview_image_action)
-
         '''preferences_action = Gio.SimpleAction.new('preferences', None)
         preferences_action.connect('activate', self.on_preferences)
         self.add_action(preferences_action)'''
@@ -81,14 +77,6 @@ class HalftoneApplication(Adw.Application):
         self.set_accels_for_action('app.save-image', ['<Primary>S'])
         #self.set_accels_for_action('app.preferences', ['<Primary>comma'])
         self.set_accels_for_action('app.quit', ['<Primary>Q', '<Primary>W'])
-
-    def show_preview_image(self, _action: Gio.SimpleAction, *args):
-        """ Helper for `show-preview-image` action. """
-
-        preview_image_path = self.window.dither_page.preview_image_path # pyright: ignore
-        image_path_variant = GLib.Variant("s", preview_image_path)
-
-        self.show_image_external(None, image_path_variant)
 
     def show_image_external(self, _action: Gio.SimpleAction | None, image_path: GLib.Variant, *args):
         """

--- a/halftone/views/dither_page.py
+++ b/halftone/views/dither_page.py
@@ -125,7 +125,6 @@ class HalftoneDitherPage(Adw.BreakpointBin):
 
         zoom_gesture.connect("begin", self.on_zoom_begin)
         zoom_gesture.connect("scale-changed", self.on_zoom_scale_changed)
-        zoom_gesture.connect("end", self.on_zoom_end)
 
         self.scrolled_window.add_controller(zoom_gesture)
 
@@ -416,15 +415,11 @@ class HalftoneDitherPage(Adw.BreakpointBin):
         self.last_y = 0.0
 
     def on_zoom_begin(self, _gesture: Gtk.GestureZoom, _sequence: Gdk.EventSequence) -> None:
-        print("Zoom gesture begin")
         self.cancel_deceleration()
         self.zoom_target = self.image_view.scale
 
     def on_zoom_scale_changed(self, _gesture: Gtk.GestureZoom, scale: float) -> None:
         self.image_view.scale = self.zoom_target * scale
-
-    def on_zoom_end(self, _gesture: Gtk.GestureZoom, _sequence: Gdk.EventSequence) -> None:
-        print("Zoom gesture end")
 
     def on_toggle_sheet(self, action: Gio.SimpleAction, *args):
         if self.is_mobile:

--- a/halftone/views/dither_page.py
+++ b/halftone/views/dither_page.py
@@ -74,6 +74,8 @@ class HalftoneDitherPage(Adw.BreakpointBin):
         self.is_image_ready: bool = False
         self.is_mobile: bool = False
 
+        self.zoom_target: float = 1.0
+
         self.last_x: float = 0.0
         self.last_y: float = 0.0
 
@@ -117,6 +119,15 @@ class HalftoneDitherPage(Adw.BreakpointBin):
         drag_gesture.connect("drag-end", self.on_drag_end)
 
         self.scrolled_window.add_controller(drag_gesture)
+
+        # Zoom using 2-finger pinch/zoom gestures
+        zoom_gesture = Gtk.GestureZoom.new()
+
+        zoom_gesture.connect("begin", self.on_zoom_begin)
+        zoom_gesture.connect("scale-changed", self.on_zoom_scale_changed)
+        zoom_gesture.connect("end", self.on_zoom_end)
+
+        self.scrolled_window.add_controller(zoom_gesture)
 
     def setup_actions(self):
         """ `zoom.*` action group """
@@ -403,6 +414,17 @@ class HalftoneDitherPage(Adw.BreakpointBin):
         self.image_view.set_cursor(None)
         self.last_x = 0.0
         self.last_y = 0.0
+
+    def on_zoom_begin(self, _gesture: Gtk.GestureZoom, _sequence: Gdk.EventSequence) -> None:
+        print("Zoom gesture begin")
+        self.cancel_deceleration()
+        self.zoom_target = self.image_view.scale
+
+    def on_zoom_scale_changed(self, _gesture: Gtk.GestureZoom, scale: float) -> None:
+        self.image_view.scale = self.zoom_target * scale
+
+    def on_zoom_end(self, _gesture: Gtk.GestureZoom, _sequence: Gdk.EventSequence) -> None:
+        print("Zoom gesture end")
 
     def on_toggle_sheet(self, action: Gio.SimpleAction, *args):
         if self.is_mobile:

--- a/halftone/views/dither_page.py
+++ b/halftone/views/dither_page.py
@@ -49,7 +49,6 @@ class HalftoneDitherPage(Adw.BreakpointBin):
     image_height_row: Adw.SpinRow = Gtk.Template.Child()
 
     image_formats_stringlist: Gtk.StringList = Gtk.Template.Child()
-    algorithms_stringlist: Gtk.StringList = Gtk.Template.Child()
 
     color_amount_row: Adw.SpinRow = Gtk.Template.Child()
 
@@ -134,18 +133,7 @@ class HalftoneDitherPage(Adw.BreakpointBin):
         # By default keep image aspect ratio
         self.aspect_ratio_toggle.set_active(True)
 
-        self.setup_dither_algorithms()
         self.setup_save_formats()
-
-    def setup_dither_algorithms(self):
-        algorithms_list = [
-            "Floyd-Steinberg",
-            "Riemersma",
-            "Bayer (ordered)"
-        ]
-
-        for algorithm in algorithms_list:
-            self.algorithms_stringlist.append(algorithm)
 
     def setup_save_formats(self):
         output_formats = get_output_formats(True) # TODO: Add a setting to toggle showing all formats

--- a/halftone/views/dither_page.py
+++ b/halftone/views/dither_page.py
@@ -29,6 +29,8 @@ LOADING_OVERLAY_DELAY = 2000  # In milliseconds
 class HalftoneDitherPage(Adw.BreakpointBin):
     __gtype_name__ = "HalftoneDitherPage"
 
+    shortcut_controller: Gtk.ShortcutController = Gtk.Template.Child()
+
     image_viewport: Gtk.Viewport = Gtk.Template.Child()
 
     image_preferences_bin: Adw.Bin = Gtk.Template.Child()
@@ -133,6 +135,26 @@ class HalftoneDitherPage(Adw.BreakpointBin):
 
         self.install_action("zoom.in", None, self.image_view.on_zoom)
         self.install_action("zoom.out", None, self.image_view.on_zoom)
+
+        # Add bindings for `zoom.*` action group
+
+        zoom_in_shortcuts = [
+            (Gdk.KEY_equal, []),
+            (Gdk.KEY_equal, [Gdk.ModifierType.CONTROL_MASK]),
+            (Gdk.KEY_plus, []),
+            (Gdk.KEY_plus, [Gdk.ModifierType.CONTROL_MASK]),
+            (Gdk.KEY_KP_Add, []),
+            (Gdk.KEY_KP_Add, [Gdk.ModifierType.CONTROL_MASK])
+        ]
+        self.add_shortcuts("zoom.in", zoom_in_shortcuts)
+
+        zoom_out_shortcuts = [
+            (Gdk.KEY_minus, []),
+            (Gdk.KEY_minus, [Gdk.ModifierType.CONTROL_MASK]),
+            (Gdk.KEY_KP_Subtract, []),
+            (Gdk.KEY_KP_Subtract, [Gdk.ModifierType.CONTROL_MASK]),
+        ]
+        self.add_shortcuts("zoom.out", zoom_out_shortcuts)
 
     def connect_signals(self):
         self.image_view.connect("zoom-changed",
@@ -597,6 +619,20 @@ class HalftoneDitherPage(Adw.BreakpointBin):
     def set_size_spins(self, width: int, height: int):
         self.image_width_row.set_value(width)
         self.image_height_row.set_value(height)
+
+    def add_shortcuts(self, action_name: str, shortcut_list: list[tuple[int, list[Gdk.ModifierType]]]) -> None:
+        for key, modifiers in shortcut_list:
+            modifier = Gdk.ModifierType.NO_MODIFIER_MASK
+
+            for m in modifiers:
+                modifier = modifier | m
+
+            shortcut = Gtk.Shortcut.new(
+                Gtk.KeyvalTrigger.new(key, modifier),
+                Gtk.NamedAction.new(action_name)
+            )
+
+            self.shortcut_controller.add_shortcut(shortcut)
 
     def update_adjustment(self, x: float, y: float) -> None:
         self.scrolled_window.get_hadjustment().set_value(

--- a/halftone/views/dither_page.py
+++ b/halftone/views/dither_page.py
@@ -143,9 +143,6 @@ class HalftoneDitherPage(Adw.BreakpointBin):
         self.mobile_breakpoint.connect("unapply",
             self.on_breakpoint_unapply)
 
-        '''self.settings.connect("changed::preview-content-fit",
-            self.update_preview_content_fit)'''
-
     def setup(self):
         # Set utility page in sidebar by default
         self.sidebar_view.set_content(self.image_preferences_bin)
@@ -571,22 +568,6 @@ class HalftoneDitherPage(Adw.BreakpointBin):
         algorithm_string = __get_algorithm_string()
 
         return algorithm_string
-
-    '''def update_preview_content_fit(self, *args):
-        selected_content_fit = self.settings.get_int("preview-content-fit")
-
-        content_fit = Gtk.ContentFit.FILL
-
-        if selected_content_fit == 0:
-            content_fit = Gtk.ContentFit.FILL
-        elif selected_content_fit == 1:
-            content_fit = Gtk.ContentFit.CONTAIN
-        elif selected_content_fit == 2:
-            content_fit = Gtk.ContentFit.COVER
-        elif selected_content_fit == 3:
-            content_fit = Gtk.ContentFit.SCALE_DOWN
-
-        self.image_view.set_content_fit(content_fit)'''
 
     def set_size_spins(self, width: int, height: int):
         self.image_width_row.set_value(width)

--- a/halftone/views/dither_page.py
+++ b/halftone/views/dither_page.py
@@ -27,10 +27,9 @@ LOADING_OVERLAY_DELAY = 2000  # In milliseconds
 class HalftoneDitherPage(Adw.BreakpointBin):
     __gtype_name__ = "HalftoneDitherPage"
 
-    image_box: Gtk.Box = Gtk.Template.Child()
-    image_dithered: Gtk.Picture = Gtk.Template.Child()
+    image_view: Gtk.Picture = Gtk.Template.Child()
 
-    image_prefs_bin: Adw.Bin = Gtk.Template.Child()
+    image_preferences_bin: Adw.Bin = Gtk.Template.Child()
 
     split_view: Adw.OverlaySplitView = Gtk.Template.Child()
     sidebar_view: Adw.ToolbarView = Gtk.Template.Child()
@@ -38,10 +37,9 @@ class HalftoneDitherPage(Adw.BreakpointBin):
     bottom_sheet_box: Gtk.Box = Gtk.Template.Child()
     bottom_sheet: Adw.Bin = Gtk.Template.Child()
 
-    preview_scroll_window: Gtk.ScrolledWindow = Gtk.Template.Child()
+    scrolled_window: Gtk.ScrolledWindow = Gtk.Template.Child()
 
     save_image_button: Gtk.Button = Gtk.Template.Child()
-    toggle_sheet_button: Gtk.Button = Gtk.Template.Child()
 
     export_format_combo: Adw.ComboRow = Gtk.Template.Child()
     dither_algorithms_combo: Adw.ComboRow = Gtk.Template.Child()
@@ -50,16 +48,12 @@ class HalftoneDitherPage(Adw.BreakpointBin):
     aspect_ratio_toggle: Adw.SwitchRow = Gtk.Template.Child()
     image_height_row: Adw.SpinRow = Gtk.Template.Child()
 
-    brightness_row: Adw.SpinRow = Gtk.Template.Child()
-    contrast_row: Adw.SpinRow = Gtk.Template.Child()
-
     image_formats_stringlist: Gtk.StringList = Gtk.Template.Child()
     algorithms_stringlist: Gtk.StringList = Gtk.Template.Child()
 
     color_amount_row: Adw.SpinRow = Gtk.Template.Child()
 
     save_image_dialog: Gtk.FileDialog = Gtk.Template.Child()
-    all_filter: Gtk.FileFilter = Gtk.Template.Child()
 
     preview_loading_overlay: Gtk.Box = Gtk.Template.Child()
 
@@ -79,14 +73,14 @@ class HalftoneDitherPage(Adw.BreakpointBin):
         self.is_image_ready: bool = False
         self.is_mobile: bool = False
 
-        self.origin_x: float = None
-        self.origin_y: float = None
+        self.last_x: float = 0.0
+        self.last_y: float = 0.0
 
         self.task_id: int | None = None
         self.tasks: list[KillableThread] = []
 
-        self.input_image_path: str = None
-        self.preview_image_path: str = None
+        self.input_image_path: str = ""
+        self.preview_image_path: str = ""
 
         self.original_paintable: Gdk.Paintable = None
         self.updated_paintable: Gdk.Paintable = None
@@ -94,11 +88,22 @@ class HalftoneDitherPage(Adw.BreakpointBin):
         self.output_options: OutputOptions = OutputOptions()
         self.keep_aspect_ratio: bool = True
 
-        self.setup_signals()
+        self.setup_gestures()
+        self.connect_signals()
         self.setup()
-        self.setup_controllers()
 
-    def setup_signals(self):
+    def setup_gestures(self):
+        # Drag for moving image around
+        drag_gesture = Gtk.GestureDrag.new()
+        drag_gesture.set_button(0)
+
+        drag_gesture.connect("drag-begin", self.on_drag_begin)
+        drag_gesture.connect("drag-update", self.on_drag_update)
+        drag_gesture.connect("drag-end", self.on_drag_end)
+
+        self.scrolled_window.add_controller(drag_gesture)
+
+    def connect_signals(self):
         self.aspect_ratio_toggle.connect("notify::active",
             self.on_aspect_ratio_toggled)
 
@@ -119,7 +124,7 @@ class HalftoneDitherPage(Adw.BreakpointBin):
 
     def setup(self):
         # Set utility page in sidebar by default
-        self.sidebar_view.set_content(self.image_prefs_bin)
+        self.sidebar_view.set_content(self.image_preferences_bin)
 
         # Workaround: Set default values for SpinRows
         self.color_amount_row.set_value(10)
@@ -149,24 +154,6 @@ class HalftoneDitherPage(Adw.BreakpointBin):
             self.image_formats_stringlist.append(filetype.as_extension())
 
         self.export_format_combo.set_selected(output_formats.index(FileType.PNG))
-
-    def setup_controllers(self):
-        preview_drag_ctrl = Gtk.GestureDrag.new()
-        preview_drag_ctrl.connect("drag-begin", self.preview_drag_begin)
-        preview_drag_ctrl.connect("drag-update", self.preview_drag_update)
-
-        self.preview_scroll_window.add_controller(preview_drag_ctrl)
-
-    def preview_drag_begin(self, x: float, y: float, *args):
-        self.origin_x = self.preview_scroll_window.get_hadjustment().get_value()
-        self.origin_y = self.preview_scroll_window.get_vadjustment().get_value()
-
-    def preview_drag_update(self, widget: Gtk.GestureDrag, offset_x: float, offset_y: float, *args):
-        hadj = self.preview_scroll_window.get_hadjustment()
-        vadj = self.preview_scroll_window.get_vadjustment()
-
-        hadj.set_value(self.origin_x - offset_x)
-        vadj.set_value(self.origin_y - offset_y)
 
     """ Main functions """
 
@@ -241,7 +228,7 @@ class HalftoneDitherPage(Adw.BreakpointBin):
                 action_target=GLib.Variant("s", output_path))
         )
 
-    """ Signal callbacks """
+    """ Callbacks """
 
     @Gtk.Template.Callback()
     def on_color_amount_changed(self, widget: Adw.SpinRow):
@@ -340,6 +327,30 @@ class HalftoneDitherPage(Adw.BreakpointBin):
         self.save_image_dialog.set_initial_name(output_filename)
         self.save_image_dialog.save(self.win, None, self.on_image_dialog_result)
 
+    def on_drag_begin(self, gesture: Gtk.GestureDrag, _x: float, _y: float) -> None:
+        device = gesture.get_device()
+
+        # Allow only left and middle button
+        if (not gesture.get_current_button() in [1, 2] or
+            # Drag gesture for touchscreens is handled by ScrolledWindow
+            device and device.get_source() == Gdk.InputSource.TOUCHSCREEN):
+            gesture.set_state(Gtk.EventSequenceState.DENIED)
+            return
+
+        self.image_view.set_cursor_from_name("grabbing")
+        self.last_x = 0.0
+        self.last_y = 0.0
+
+    def on_drag_update(self, _gesture: Gtk.GestureDrag, x: float, y: float) -> None:
+        self.update_adjustment(x, y)
+        self.last_x = x
+        self.last_y = y
+
+    def on_drag_end(self, _gesture: Gtk.GestureDrag, _x: float, _y: float) -> None:
+        self.image_view.set_cursor(None)
+        self.last_x = 0.0
+        self.last_y = 0.0
+
     def on_toggle_sheet(self, action: Gio.SimpleAction, *args):
         if self.is_mobile:
             if self.bottom_sheet_box.props.visible:
@@ -407,24 +418,24 @@ class HalftoneDitherPage(Adw.BreakpointBin):
 
     def on_successful_image_load(self, *args):
         self.preview_loading_overlay.set_visible(False)
-        self.image_dithered.remove_css_class("preview-loading-blur")
+        self.image_view.remove_css_class("preview-loading-blur")
         self.save_image_button.set_sensitive(True)
 
     def on_awaiting_image_load(self, *args):
         if not self.is_image_ready:
             self.preview_loading_overlay.set_visible(True)
-            self.image_dithered.add_css_class("preview-loading-blur")
+            self.image_view.add_css_class("preview-loading-blur")
             self.save_image_button.set_sensitive(False)
 
     def on_breakpoint_apply(self, *args):
         self.sidebar_view.set_content(None)
-        self.bottom_sheet.set_child(self.image_prefs_bin)
+        self.bottom_sheet.set_child(self.image_preferences_bin)
 
         self.is_mobile = True
 
     def on_breakpoint_unapply(self, *args):
         self.bottom_sheet.set_child(None)
-        self.sidebar_view.set_content(self.image_prefs_bin)
+        self.sidebar_view.set_content(self.image_preferences_bin)
 
         self.is_mobile = False
 
@@ -446,7 +457,7 @@ class HalftoneDitherPage(Adw.BreakpointBin):
             self.win.latest_traceback = logging.get_traceback(e)
             raise
 
-        self.image_dithered.set_paintable(self.original_paintable)
+        self.image_view.set_paintable(self.original_paintable)
 
     def set_updated_paintable(self, path: str):
         try:
@@ -464,7 +475,7 @@ class HalftoneDitherPage(Adw.BreakpointBin):
             self.win.latest_traceback = logging.get_traceback(e)
             raise
 
-        self.image_dithered.set_paintable(self.updated_paintable)
+        self.image_view.set_paintable(self.updated_paintable)
 
     def clean_preview_paintable(self):
         try:
@@ -527,11 +538,19 @@ class HalftoneDitherPage(Adw.BreakpointBin):
         elif selected_content_fit == 3:
             content_fit = Gtk.ContentFit.SCALE_DOWN
 
-        self.image_dithered.set_content_fit(content_fit)
+        self.image_view.set_content_fit(content_fit)
 
     def set_size_spins(self, width: int, height: int):
         self.image_width_row.set_value(width)
         self.image_height_row.set_value(height)
+
+    def update_adjustment(self, x: float, y: float) -> None:
+        self.scrolled_window.get_hadjustment().set_value(
+            self.scrolled_window.get_hadjustment().get_value() - x + self.last_x
+        )
+        self.scrolled_window.get_vadjustment().set_value(
+            self.scrolled_window.get_vadjustment().get_value() - y + self.last_y
+        )
 
     def start_task(self, task: Callable, *args): #callback: callable
         logging.debug("Starting new async task")

--- a/halftone/views/image_view.py
+++ b/halftone/views/image_view.py
@@ -1,0 +1,162 @@
+# Copyright 2025, tfuxu <https://github.com/tfuxu>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# NOTE: This code is mostly a port of the `Image Scaling` example from gtk4-demo: https://gitlab.gnome.org/GNOME/gtk/-/blob/main/demos/gtk-demo/imageview.c
+
+import math
+
+from gi.repository import Adw, Gtk, Gdk, Gsk, Gio, GLib, Graphene, GObject
+
+
+class HalftoneImageView(Gtk.Widget):
+    __gtype_name__ = "HalftoneImageView"
+
+    _texture: Gdk.Texture | None
+    _scaling_filter = Gsk.ScalingFilter.LINEAR
+
+    _scale = 1.0
+
+    def __init__(self, parent: Gtk.Widget, texture: Gdk.Texture | None, **kwargs):
+        super().__init__(**kwargs)
+
+        self.parent = parent
+        self.settings: Gio.Settings = parent.settings
+
+        self.app: Adw.Application = self.parent.get_application()
+        self.win: Adw.ApplicationWindow = self.app.get_active_window()
+
+        self.set_accessible_role(Gtk.AccessibleRole.IMG)
+
+        self._texture = texture
+
+    """ Properties """
+
+    @GObject.Property(type=Gdk.Texture)
+    def texture(self) -> Gdk.Texture | None:
+        return self._texture
+
+    @texture.setter
+    def set_texture(self, texture: Gdk.Texture) -> None:
+        self._texture = texture
+        self._scale = 1.0
+        self._scaling_filter = Gsk.ScalingFilter.LINEAR
+
+        self.queue_resize()
+
+        self.notify("scale")
+        self.notify("scaling_filter")
+
+    @GObject.Property(type=float, minimum=1.0/1024.0, maximum=1024.0, default=1.0)
+    def scale(self) -> float:
+        return self._scale
+
+    @scale.setter
+    def set_scale(self, scale: float) -> None:
+        self._scale = scale
+
+        self.queue_resize()
+
+    @GObject.Property(type=Gsk.ScalingFilter, default=Gsk.ScalingFilter.LINEAR)
+    def scaling_filter(self) -> Gsk.ScalingFilter:
+        return self._scaling_filter
+
+    @scaling_filter.setter
+    def set_scaling_filter(self, filter: Gsk.ScalingFilter) -> None:
+        self._scaling_filter = filter
+
+        self.queue_resize()
+
+    @GObject.Property(type=bool, default=True)
+    def can_zoom_in(self) -> bool:
+        return self._scale < 1024.0
+
+    @GObject.Property(type=bool, default=True)
+    def can_zoom_out(self) -> bool:
+        return self._scale > 1.0/1024.0
+
+    @GObject.Property(type=bool, default=False)
+    def can_reset_zoom(self) -> bool:
+        return self._scale != 1.0
+
+    """ Signals """
+
+    @GObject.Signal(name="zoom-changed")
+    def zoom_changed(self):
+        pass
+
+    """ Overrides """
+
+    # Here's where the zoom magic happens
+    def do_snapshot(self, snapshot: Gdk.Snapshot) -> None:
+        width = self.get_width()
+        height = self.get_height()
+
+        if self.texture is None:
+            return
+
+        new_width = self.scale * self.texture.get_width()
+        new_height = self.scale * self.texture.get_height()
+
+        x = (width - math.ceil(new_width)) / 2
+        y = (height - math.ceil(new_height)) / 2
+
+        snapshot.push_clip(Graphene.Rect().alloc().init(0, 0, width, height))
+        snapshot.save()
+        snapshot.translate(Graphene.Point().alloc().init(x, y))
+        snapshot.translate(Graphene.Point().alloc().init(new_width / 2, new_height / 2))
+        snapshot.translate(Graphene.Point().alloc().init(-new_width / 2, -new_height / 2))
+        snapshot.append_scaled_texture(
+            self.texture,
+            self.scaling_filter,
+            Graphene.Rect().alloc().init(0, 0, new_width, new_height)
+        )
+
+        snapshot.restore()
+        snapshot.pop()
+
+        self.emit("zoom-changed")
+
+    # NOTE: Needed for Gtk.Viewport to implement scrollability
+    # TODO: Interface with `Gtk.Scrollable` to enable more capabilities
+    def do_measure(self, orientation: Gtk.Orientation, for_size: int) -> tuple[int, int, int, int]:
+        baseline = self.get_baseline()
+        size: int
+
+        if self.texture is None:
+            return (0, 0, baseline, baseline)
+
+        width = self.texture.get_width()
+        height = self.texture.get_height()
+
+        if orientation == Gtk.Orientation.HORIZONTAL:
+            size = width
+        else:
+            size = height
+
+        minimum = natural = math.ceil(self.scale * size)
+        return (minimum, natural, baseline, baseline)
+
+    """ Callbacks """
+
+    def on_zoom(self, _widget: Gtk.Widget, action_name: str, _parameter: GLib.Variant | None):
+        scale: float
+
+        match action_name:
+            case "zoom.in":
+                scale = min(1024.0, self.scale * math.sqrt(2))
+            case "zoom.out":
+                scale = max(1.0/1024.0, self.scale / math.sqrt(2))
+            case "zoom.reset":
+                scale = 1.0
+            case _:
+                raise ValueError("Invalid action name provided. Make sure it's from \"zoom.*\" namespace.")
+
+        self.scale = scale
+
+    """ Public methods """
+
+    def zoom_in(self):
+        self.scale = min(1024.0, self.scale * math.sqrt(2))
+
+    def zoom_out(self):
+        self.scale = max(1.0/1024.0, self.scale / math.sqrt(2))

--- a/halftone/views/image_view.py
+++ b/halftone/views/image_view.py
@@ -155,8 +155,14 @@ class HalftoneImageView(Gtk.Widget):
 
     """ Public methods """
 
-    def zoom_in(self):
+    def zoom_to(self, zoom: float) -> None:
+        self.scale = zoom
+
+    def zoom_in(self) -> None:
         self.scale = min(1024.0, self.scale * math.sqrt(2))
 
-    def zoom_out(self):
+    def zoom_out(self) -> None:
         self.scale = max(1.0/1024.0, self.scale / math.sqrt(2))
+
+    def reset_zoom(self) -> None:
+        self.scale = 1.0


### PR DESCRIPTION
This PR implements a custom image widget equipped with zoom capabilities. It supports linear, nearest and trilinear scaling filters, which should reduce occurrences of the moiré patterns, as we automatically switch from linear to nearest filter after passing scale >= 100% threshold.

Most image viewer controls are implemented, including scroll-to-zoom, image dragging and dedicated zoom in and zoom out buttons.

### Things that could be implemented in the future:
- Smooth zooming
- Best fit (it fits the image to the size of the window, possibly eliminating remaining instances of moiré patterns showing up)
- Zoom to the center, or to where the mouse is pointing
- More control with zoom, ie. allow users to type a specific zoom value (something like what Loupe currently has)
- Reset zoom button (I just need to come up with a design)
- Different zoom factors for different devices (different for scroll wheel, touchpad, touchscreen, etc.)

### Currently untested:
- ~How zoom behaves on touchscreens and touchpads~ Tested and properly implemented

### Screenshots:
Zoomed in:
![Screenshot From 2025-05-12 22-43-54](https://github.com/user-attachments/assets/9bd594bd-5431-4ef4-ad4d-3282e8bde012)

Zoomed out:
![Screenshot From 2025-05-12 22-44-14](https://github.com/user-attachments/assets/4dd1d343-0d39-4f32-92dd-4e7f083eba6d)