### PR TITLE
implement the simple circle request

### DIFF
--- a/data/halftone.gresource.xml
+++ b/data/halftone.gresource.xml
@@ -13,7 +13,6 @@
     <file>style.css</file>
   </gresource>
   <gresource prefix="/io/github/tfuxu/Halftone/icons/scalable/actions/">
-    <file preprocess="xml-stripblanks" alias="arrow-into-box-symbolic.svg">icons/scalable/actions/arrow-into-box-symbolic.svg</file>
     <file preprocess="xml-stripblanks" alias="chain-link-symbolic.svg">icons/scalable/actions/chain-link-symbolic.svg</file>
     <file preprocess="xml-stripblanks" alias="chain-link-loose-symbolic.svg">icons/scalable/actions/chain-link-loose-symbolic.svg</file>
     <file preprocess="xml-stripblanks" alias="document-save-symbolic.svg">icons/scalable/actions/document-save-symbolic.svg</file>

--- a/data/ui/dither_page.blp
+++ b/data/ui/dither_page.blp
@@ -20,6 +20,7 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
 
           [top]
           Adw.HeaderBar desktop_sidebar_headerbar {
+            centering-policy: strict;
 
             [start]
             Gtk.Button {

--- a/data/ui/dither_page.blp
+++ b/data/ui/dither_page.blp
@@ -20,13 +20,26 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
 
           [top]
           Adw.HeaderBar desktop_sidebar_headerbar {
-            centering-policy: strict;
 
             [start]
             Gtk.Button {
+              width-request: 1;
+              hexpand: false;
+              halign: start;
+
+              child: Box {
+                spacing:6;
+                Image {
+                  icon-name:"folder-open-symbolic";
+                }
+                Label {
+                  label: _("Open");
+
+                }
+              };
               tooltip-text: _("Open Image (Ctrl+O)");
-              icon-name: "arrow-into-box-symbolic";
               action-name: "app.open-image";
+              styles ["flat"]
             }
 
             [end]
@@ -80,7 +93,7 @@ template $HalftoneDitherPage: Adw.BreakpointBin {
           [start]
           Gtk.Button {
             tooltip-text: _("Open Image (Ctrl+O)");
-            icon-name: "arrow-into-box-symbolic";
+            icon-name: "folder-open-symbolic";
             action-name: "app.open-image";
           }
 
@@ -189,3 +202,4 @@ menu main_menu {
     }
   }
 }
+

--- a/halftone/views/dither_page.py
+++ b/halftone/views/dither_page.py
@@ -308,7 +308,7 @@ class HalftoneDitherPage(Adw.BreakpointBin):
 
     def _get_output_format_suffix(self) -> str:
         selected_format = self.image_options_view.export_format_combo.props.selected
-        format_string = self.image_options_view.image_formats_stringlist.get_string(selected_format)
+        format_string = self.image_options_view.image_formats_stringlist.get_string(selected_format).lower()
 
         # NOTE: This should only happen if the list isn't populated
         if format_string is None:

--- a/halftone/views/image_options_view.py
+++ b/halftone/views/image_options_view.py
@@ -80,7 +80,7 @@ class HalftoneImageOptionsView(Adw.Bin):
         output_formats = get_output_formats(True) # TODO: Add a setting to toggle showing all formats
 
         for filetype in output_formats:
-            self.image_formats_stringlist.append(filetype.as_extension())
+            self.image_formats_stringlist.append(filetype.as_extension().upper())
 
         self.export_format_combo.set_selected(output_formats.index(FileType.PNG))
 
@@ -174,7 +174,8 @@ class HalftoneImageOptionsView(Adw.Bin):
 
     def on_save_format_selected(self, widget: Adw.ComboRow, *args) -> None:
         selected_format = widget.props.selected
-        format_string = self.image_formats_stringlist.get_string(selected_format)
+        format_string = self.image_formats_stringlist.get_string(selected_format).lower()
+        print(format_string)
 
         self.output_options.output_format = format_string
 

--- a/halftone/views/image_options_view.py
+++ b/halftone/views/image_options_view.py
@@ -175,7 +175,6 @@ class HalftoneImageOptionsView(Adw.Bin):
     def on_save_format_selected(self, widget: Adw.ComboRow, *args) -> None:
         selected_format = widget.props.selected
         format_string = self.image_formats_stringlist.get_string(selected_format).lower()
-        print(format_string)
 
         self.output_options.output_format = format_string
 


### PR DESCRIPTION
Fixes the issue of image formats not being uppercase and updates the 'Open' button to match the requested design. As mentioned in the Circle [thread](https://gitlab.gnome.org/Teams/Circle/-/issues/208).

<img width="871" height="791" alt="image" src="https://github.com/user-attachments/assets/a1340476-e0c8-4757-a58d-a20487c73727" />
