### PR TITLE
Remove `/tmp` folder permission and deprecated `app-id` field.

### DIFF
--- a/build-aux/flatpak/io.github.tfuxu.Halftone.json
+++ b/build-aux/flatpak/io.github.tfuxu.Halftone.json
@@ -1,5 +1,5 @@
 {
-  "app-id": "io.github.tfuxu.Halftone",
+  "id": "io.github.tfuxu.Halftone",
   "runtime": "org.gnome.Platform",
   "runtime-version": "48",
   "sdk": "org.gnome.Sdk",
@@ -8,8 +8,7 @@
     "--share=ipc",
     "--device=dri",
     "--socket=fallback-x11",
-    "--socket=wayland",
-    "--filesystem=/tmp"
+    "--socket=wayland"
   ],
   "cleanup": [
     "/include",


### PR DESCRIPTION
The "External Image Viewer" button appears to be gone, and the other uses of the `/tmp` directory can be fulfilled by Flatpak's local tmp directory. So I removed the permission from the Flatpak manifest and also changed `app-id` to `id` because the former is deprecated.

Closes #90