### PR TITLE
Replace style-dark.css with media query

### DIFF
--- a/data/halftone.gresource.xml
+++ b/data/halftone.gresource.xml
@@ -7,7 +7,6 @@
     <file preprocess="xml-stripblanks">ui/image_options_view.ui</file>
     <file preprocess="xml-stripblanks">ui/image_view.ui</file>
     <file preprocess="xml-stripblanks">ui/main_window.ui</file>
-    <file>style-dark.css</file>
     <file>style.css</file>
   </gresource>
   <gresource prefix="/io/github/tfuxu/Halftone/icons/scalable/actions/">

--- a/data/style-dark.css
+++ b/data/style-dark.css
@@ -1,3 +1,0 @@
-:root {
-  --osd-background-color: rgba(0, 0, 0, 0.65);
-}

--- a/data/style.css
+++ b/data/style.css
@@ -1,6 +1,12 @@
 :root {
   --osd-background-color: rgba(240, 240, 240, 0.75);
 }
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --osd-background-color: rgba(0, 0, 0, 0.65);
+  }
+}
 
 .dragndrop_overlay {
   background-color: alpha(var(--accent-bg-color), 0.5);

--- a/meson.build
+++ b/meson.build
@@ -45,8 +45,8 @@ endif
 
 # Required dependencies
 dependency('glib-2.0')
-dependency('gtk4', version: '>= 4.12.0')
-dependency('libadwaita-1', version: '>= 1.5.0')
+dependency('gtk4', version: '>= 4.20.0')
+dependency('libadwaita-1', version: '>= 1.8.0')
 dependency('pygobject-3.0', version: '>= 3.48.0')
 
 # Python installation directory


### PR DESCRIPTION
Libadwaita 1.9 deprecates using style-dark.css. This moves these styles into style.css and conditionally loads them using media queries. Media queries are supported from libadwaita 1.8 (GNOME 49).